### PR TITLE
WIP: Allow parquet changes

### DIFF
--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -166,6 +166,26 @@ under the License.
 				</executions>
 			</plugin>
 
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.1.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier>kdayanand</classifier>
+							<includes>
+								<include>**/service/*</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
 			<!-- skip dependency convergence due to Hadoop dependency -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -178,9 +178,6 @@ under the License.
 						</goals>
 						<configuration>
 							<classifier>kdayanand</classifier>
-							<includes>
-								<include>**/service/*</include>
-							</includes>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/StreamOutputFile.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/StreamOutputFile.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.parquet;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.Public;
 import org.apache.flink.core.fs.FSDataOutputStream;
 
 import org.apache.parquet.io.OutputFile;
@@ -35,8 +36,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * <p>Because the implementation goes against an open stream, rather than open its
  * own streams against a file, instances can create one stream only.
  */
-@Internal
-class StreamOutputFile implements OutputFile {
+@Public
+public class StreamOutputFile implements OutputFile {
 
 	private static final long DEFAULT_BLOCK_SIZE = 64L * 1024L * 1024L;
 
@@ -50,7 +51,7 @@ class StreamOutputFile implements OutputFile {
 	 *
 	 * @param stream The stream to write to.
 	 */
-	StreamOutputFile(FSDataOutputStream stream) {
+	public StreamOutputFile(FSDataOutputStream stream) {
 		this.stream = checkNotNull(stream);
 		this.used = new AtomicBoolean(false);
 	}


### PR DESCRIPTION
All the StreamOutputFile to be public so that it can be used by other (similar to ParquetWriters) BultWriters where the configuration needs to be modified. 